### PR TITLE
[FC-0004] API to manage certificate signatures

### DIFF
--- a/credentials/apps/api/v2/permissions.py
+++ b/credentials/apps/api/v2/permissions.py
@@ -53,11 +53,10 @@ class CanReplaceUsername(permissions.BasePermission):
 
 class IsAdminUserOrReadOnly(permissions.BasePermission):
     """
-    Grants access to edit only the administrator.
+    Grants access to edit only the staff.
+    Grants read access to all users.
     """
-
-    SAFE_METHODS = ('GET', 'HEAD', 'OPTIONS')
 
     def has_permission(self, request, view):
         is_admin_user = request.user and (request.user.is_superuser or request.user.is_staff)
-        return request.method in self.SAFE_METHODS or is_admin_user
+        return is_admin_user or request.method in permissions.SAFE_METHODS

--- a/credentials/apps/api/v2/permissions.py
+++ b/credentials/apps/api/v2/permissions.py
@@ -49,3 +49,15 @@ class CanReplaceUsername(permissions.BasePermission):
 
     def has_permission(self, request, view):
         return request.user.username == settings.USERNAME_REPLACEMENT_WORKER
+
+
+class IsAdminUserOrReadOnly(permissions.BasePermission):
+    """
+    Grants access to edit only the administrator.
+    """
+
+    SAFE_METHODS = ('GET', 'HEAD', 'OPTIONS')
+
+    def has_permission(self, request, view):
+        is_admin_user = request.user and (request.user.is_superuser or request.user.is_staff)
+        return request.method in self.SAFE_METHODS or is_admin_user

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -4,6 +4,7 @@ from logging import WARNING
 from uuid import uuid4
 
 import ddt
+import json
 import pytz
 from django.test import TestCase
 from django.urls import reverse
@@ -14,6 +15,7 @@ from rest_framework.test import APIRequestFactory
 from credentials.apps.api.v2.serializers import (
     CourseCertificateSerializer,
     CredentialField,
+    SignatorySerializer,
     UserCredentialAttributeSerializer,
     UserCredentialCreationSerializer,
     UserCredentialSerializer,
@@ -24,7 +26,9 @@ from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.models import CourseCertificate
 from credentials.apps.credentials.tests.factories import (
     CourseCertificateFactory,
+    create_test_image,
     ProgramCertificateFactory,
+    SignatoryFactory,
     UserCredentialAttributeFactory,
     UserCredentialFactory,
 )
@@ -295,6 +299,56 @@ class UserCredentialSerializerTests(TestCase):
         self.assertEqual(actual, expected)
 
 
+class SignatorySerializerTests(SiteMixin, TestCase):
+    def test_create_signatory(self):
+        signatory = SignatoryFactory()
+
+        actual = SignatorySerializer(signatory).data
+        expected = {
+            "name": signatory.name,
+            "title": signatory.title,
+            "organization_name_override": signatory.organization_name_override,
+            "image": signatory.image.url,
+        }
+        self.assertEqual(actual, expected)
+
+    def test_create_signatory_missing_image(self):
+        signatory = SignatoryFactory(image=None)
+
+        actual = SignatorySerializer(signatory).data
+        expected = {
+            "name": signatory.name,
+            "title": signatory.title,
+            "organization_name_override": signatory.organization_name_override,
+            "image": None,
+        }
+        self.assertEqual(actual, expected)
+
+    def test_validation(self):
+        png_image = create_test_image("png")
+        data = {
+            "image": png_image,
+            "name": "signatory 1",
+            "organization": "edX",
+            "title": "title"
+        }
+        actual = SignatorySerializer(data=data).is_valid()
+
+        self.assertEqual(actual, True)
+
+    def test_validation_with_wrong_image_extension(self):
+        jpg_image = create_test_image("jpg")
+        data = {
+            "image": jpg_image,
+            "name": "signatory 1",
+            "organization": "edX",
+            "title": "title"
+        }
+        actual = SignatorySerializer(data=data).is_valid()
+
+        self.assertEqual(actual, False)
+
+
 class CourseCertificateSerializerTests(SiteMixin, TestCase):
     def test_create_course_certificate(self):
         course_run = CourseRunFactory()
@@ -309,6 +363,30 @@ class CourseCertificateSerializerTests(SiteMixin, TestCase):
             "certificate_type": course_certificate.certificate_type,
             "certificate_available_date": course_certificate.certificate_available_date,
             "is_active": course_certificate.is_active,
+            "signatories": [],
+            "title": course_certificate.title,
+        }
+        self.assertEqual(actual, expected)
+
+    def test_create_course_certificate_with_signatories(self):
+        course_run = CourseRunFactory()
+        course_certificate = CourseCertificateFactory(site=self.site, course_run=course_run)
+        signatory = SignatoryFactory()
+        course_certificate.signatories.add(signatory)
+        request = APIRequestFactory(site=self.site).get("/")
+
+        actual = CourseCertificateSerializer(course_certificate, context={"request": request}).data
+        expected_signatories_data = [SignatorySerializer(signatory, context={"request": request}).data]
+        expected = {
+            "id": course_certificate.id,
+            "site": self.site.id,
+            "course_id": course_certificate.course_id,
+            "course_run": course_certificate.course_run.key,
+            "certificate_type": course_certificate.certificate_type,
+            "certificate_available_date": course_certificate.certificate_available_date,
+            "is_active": course_certificate.is_active,
+            "signatories": expected_signatories_data,
+            "title": course_certificate.title,
         }
         self.assertEqual(actual, expected)
 
@@ -325,19 +403,57 @@ class CourseCertificateSerializerTests(SiteMixin, TestCase):
             "certificate_type": course_certificate.certificate_type,
             "certificate_available_date": course_certificate.certificate_available_date,
             "is_active": course_certificate.is_active,
+            "signatories": [],
+            "title": course_certificate.title,
         }
         self.assertEqual(actual, expected)
 
     def test_create_without_course_run_raises_warning(self):
         # even though you can create an entry without a course run,
         # we want to make sure we are logging a warning when it is missing
+        data = {
+            "course_id": "DemoCourse0",
+            "certificate_type": "verified",
+            "is_active": True,
+            "certificate_available_date": None,
+        }
         with self.assertLogs(level=WARNING):
-            Request = namedtuple("Request", ["site"])
-            CourseCertificateSerializer(context={"request": Request(site=self.site)}).create(
-                validated_data={
-                    "course_id": "DemoCourse0",
-                    "certificate_type": "verified",
-                    "is_active": True,
-                    "certificate_available_date": None,
-                }
+            Request = namedtuple("Request", ["site", "data", "FILES"])
+            CourseCertificateSerializer(context={"request": Request(site=self.site, data=data, FILES=None)}).create(
+                validated_data=data
             )
+
+    def test_parse_signatories_in_files(self):
+        png_image = create_test_image("png")
+        signatories_data = [{
+            "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.png",
+            "name": "signatory 1",
+            "organization": "edX",
+            "title": "title"
+        },
+        {
+            "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image+1.png",
+            "name": "signatory 2",
+            "organization": "edX",
+            "title": "title"
+        }]
+        files = {
+            "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.png": png_image,
+            "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image+1.png": png_image,
+        }
+
+        actual = CourseCertificateSerializer.parse_signatories_in_files(json.dumps(signatories_data), files)
+        expected = [{
+            "image": png_image,
+            "name": "signatory 1",
+            "organization": "edX",
+            "title": "title"
+        },
+        {
+            "image": png_image,
+            "name": "signatory 2",
+            "organization": "edX",
+            "title": "title"
+        }]
+        self.assertEqual(actual, expected)
+

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -33,6 +33,7 @@ from credentials.apps.credentials.tests.factories import (
 from credentials.apps.records.models import UserGrade
 from credentials.apps.records.tests.factories import UserGradeFactory
 
+
 JSON_CONTENT_TYPE = "application/json"
 LOGGER_NAME = "credentials.apps.credentials.issuers"
 LOGGER_NAME_SERIALIZER = "credentials.apps.api.v2.serializers"
@@ -701,8 +702,6 @@ class UsernameReplacementViewTests(JwtMixin, APITestCase):
 class CourseCertificateViewSetTests(SiteMixin, APITestCase):
     """Tests CourseCertificateViewSet"""
 
-    SERVICE_USERNAME = "test_replace_username_service_worker"
-
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
@@ -718,24 +717,28 @@ class CourseCertificateViewSetTests(SiteMixin, APITestCase):
             "certificate_available_date": self.certificate.certificate_available_date,
             "is_active": self.certificate.is_active,
             "signatories": list(self.certificate.signatories.all()),
-            "title": self.certificate.title
+            "title": self.certificate.title,
         }
         self.valid_data = {
             "course_id": "course-v1:edX+DemoX+Demo_Course",
             "certificate_type": "honor",
             "title": "Name of the certificate",
-            "signatories": json.dumps([{
-                "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.png",
-                "name": "signatory 1",
-                "organization": "edX",
-                "title": "title"
-            },
-            {
-                "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image+1.png",
-                "name": "signatory 2",
-                "organization": "edX",
-                "title": "title"
-            }]),
+            "signatories": json.dumps(
+                [
+                    {
+                        "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.png",
+                        "name": "signatory 1",
+                        "organization": "edX",
+                        "title": "title",
+                    },
+                    {
+                        "image": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image+1.png",
+                        "name": "signatory 2",
+                        "organization": "edX",
+                        "title": "title",
+                    },
+                ]
+            ),
             "is_active": True,
         }
 
@@ -745,35 +748,25 @@ class CourseCertificateViewSetTests(SiteMixin, APITestCase):
         self.client.login(username=user.username, password=USER_PASSWORD)
 
     def test_get_for_anonymous(self):
-        params = {
-            "course_id": self.certificate.course_id,
-            "certificate_type": self.certificate.certificate_type
-        }
+        params = {"course_id": self.certificate.course_id, "certificate_type": self.certificate.certificate_type}
         response = self.client.get(self.url, data=params)
-
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.certificate_data)
 
     def test_get_for_staff(self):
         self.authenticate_user(self.superuser)
-        params = {
-            "course_id": self.certificate.course_id,
-            "certificate_type": self.certificate.certificate_type
-        }
+        params = {"course_id": self.certificate.course_id, "certificate_type": self.certificate.certificate_type}
         response = self.client.get(self.url, data=params)
-
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.certificate_data)
 
     def test_post_for_anonymous(self):
         response = self.client.post(self.url, data=self.valid_data)
-
         self.assertEqual(response.status_code, 401)
 
     def test_post_for_staff(self):
         self.authenticate_user(self.superuser)
         response = self.client.post(self.url, data=self.valid_data)
-
         self.assertEqual(response.status_code, 201)
 
     def test_delete_for_anonymous(self):
@@ -784,8 +777,8 @@ class CourseCertificateViewSetTests(SiteMixin, APITestCase):
             "signatories": [],
             "is_active": True,
         }
+        self.assertEqual(CourseCertificate.objects.first(), self.certificate)
         response = self.client.delete(self.url, data=data)
-
         self.assertEqual(response.status_code, 401)
         self.assertEqual(CourseCertificate.objects.first(), self.certificate)
 
@@ -798,7 +791,7 @@ class CourseCertificateViewSetTests(SiteMixin, APITestCase):
             "signatories": [],
             "is_active": True,
         }
+        self.assertEqual(CourseCertificate.objects.first(), self.certificate)
         response = self.client.delete(self.url, data=data)
-
         self.assertEqual(response.status_code, 204)
         self.assertEqual(CourseCertificate.objects.first(), None)

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -293,10 +293,9 @@ class CourseCertificateViewSet(
     serializer_class = CourseCertificateSerializer
     permission_classes = (IsAdminUserOrReadOnly,)
     lookup_field = "course_id"
-    SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
 
     def get_object(self) -> CourseCertificate:
-        data = self.request.GET if self.request.method in self.SAFE_METHODS else self.request.data
+        data = self.request.GET if self.request.method in permissions.SAFE_METHODS else self.request.data
 
         return get_object_or_404(
             CourseCertificate,
@@ -305,8 +304,5 @@ class CourseCertificateViewSet(
         )
 
     def perform_destroy(self, instance: CourseCertificate) -> None:
-        """
-        Overriden perform_destroy to delete related signatories.
-        """
-        instance.signatories.all().delete()
+        instance.signatories.clear()
         instance.delete()

--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -2,9 +2,8 @@ import datetime
 import uuid
 
 import factory
-from factory.django import ImageField
-
 from django.core.files.base import ContentFile
+from factory.django import ImageField
 
 from credentials.apps.core.tests.factories import SiteFactory
 from credentials.apps.credentials import constants, models
@@ -13,8 +12,11 @@ from credentials.apps.credentials import constants, models
 PASSWORD = "dummy-password"
 
 
-def create_test_image(extension):
-    return ContentFile(ImageField()._make_data({"width": 1289, "height": 720}), f"example.{extension}")
+def create_image(extension: str) -> ContentFile:
+    return ContentFile(
+        ImageField()._make_data({"width": 1289, "height": 720}),  # pylint: disable=protected-access
+        f"example.{extension}",
+    )
 
 
 class AbstractCertificateFactory(factory.django.DjangoModelFactory):
@@ -73,4 +75,4 @@ class SignatoryFactory(factory.django.DjangoModelFactory):
 
     name = factory.Faker("name")
     title = factory.Faker("job")
-    image = factory.LazyAttribute(lambda _: create_test_image("png"))
+    image = factory.LazyAttribute(lambda _: create_image("png"))

--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -2,12 +2,19 @@ import datetime
 import uuid
 
 import factory
+from factory.django import ImageField
+
+from django.core.files.base import ContentFile
 
 from credentials.apps.core.tests.factories import SiteFactory
 from credentials.apps.credentials import constants, models
 
 
 PASSWORD = "dummy-password"
+
+
+def create_test_image(extension):
+    return ContentFile(ImageField()._make_data({"width": 1289, "height": 720}), f"example.{extension}")
 
 
 class AbstractCertificateFactory(factory.django.DjangoModelFactory):
@@ -22,6 +29,7 @@ class CourseCertificateFactory(AbstractCertificateFactory):
     certificate_type = constants.CertificateType.HONOR
     is_active = True
     certificate_available_date = None
+    title = factory.Faker("word")
 
 
 class ProgramCertificateFactory(AbstractCertificateFactory):
@@ -65,3 +73,4 @@ class SignatoryFactory(factory.django.DjangoModelFactory):
 
     name = factory.Faker("name")
     title = factory.Faker("job")
+    image = factory.LazyAttribute(lambda _: create_test_image("png"))


### PR DESCRIPTION
Description: This PR implements the CourseCertificateViewSet extension feature to save certificate signatories along with the configuration.
The "get" method has been added to get data about the configuration of certificates and their signatories.
Added a method to "delete" deleting the configuration of certificates and their signatories.

Youtrack: [Link to Youtrack ticket](https://youtrack.raccoongang.com/issue/EDXOLDMNG-200)


Reviewers:

 @GlugovGrGlib
 @UvgenGen
Merge checklist:

 All reviewers approved
 CI build is green
 Documentation in source code updated
 All related Confluence documentation is updated (including deployment documentation)
 Commits are squashed
Post merge:

 Delete working branch