### PR TITLE
fix: program records are absent for nutmeg-vanilla

### DIFF
--- a/credentials/templates/programs.html
+++ b/credentials/templates/programs.html
@@ -36,7 +36,7 @@
             isPublic: {{ is_public|yesno:"true,false"}},
             uuid: '{{uuid}}',
             helpUrl: '{{records_help_url}}',
-            programListUrl: '{{program_list_url}},
+            programListUrl: '{{program_list_url}}',
           });
         </script>
     {% endblock %}


### PR DESCRIPTION
**Description:**
This PR is necessary in order to fix the bug when going to page /records/programs/#UUIDprogram. Added a quote to the JS script for correct display of the Program Record page.

**YouTrack:**
https://youtrack.raccoongang.com/issue/RGOeX-24424

**Reviewers:**
- [ ] @idegtiarov 
- [ ] @dyudyunov 