### PR TITLE
chore(ci): [OeX_Cred-128] add project development branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dcc.master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dcc.master ]
 
 jobs:
   quality_and_translations_tests:


### PR DESCRIPTION
**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
