### PR TITLE
feat: [OeX_Cred-158] added 'verifiable_credentials' toggle

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -557,3 +557,13 @@ LEARNER_RECORD_MFE_RECORDS_PAGE_URL = ""
 # Plugin Django Apps
 INSTALLED_APPS.extend(get_plugin_apps(PROJECT_TYPE))
 add_plugins(__name__, PROJECT_TYPE, SettingsType.BASE)
+
+# .. toggle_name: ENABLE_VERIFIABLE_CREDENTIALS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Determines if the Credentials IDA uses digital credentials issuance.
+# .. toggle_warning: Requires the Learner Record MFE to be deployed and used in a given environment if toggled to true.
+# .. toggle_life_expectancy: permanent
+# .. toggle_permanent_justification: Digital Credentials are optional for usage.
+# .. toggle_creation_date: 2023-02-02
+ENABLE_VERIFIABLE_CREDENTIALS = False

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -64,14 +64,18 @@ urlpatterns = oauth2_urlpatterns + [
     re_path(r"^favicon\.ico$", FaviconView.as_view(permanent=True)),
     re_path(r"^mock-toggles$", MockToggleStateView.as_view()),
     re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
-    re_path(
-        r"^verifiable-credentials/",
-        include(
-            ("credentials.apps.verifiable_credentials.urls", "verifiable_credentials"),
-            namespace="verifiable_credentials",
-        ),
-    ),
 ]
+
+if settings.ENABLE_VERIFIABLE_CREDENTIALS:
+    urlpatterns += [
+        re_path(
+            r"^verifiable-credentials/",
+            include(
+                ("credentials.apps.verifiable_credentials.urls", "verifiable_credentials"),
+                namespace="verifiable_credentials",
+            ),
+        ),
+    ]
 
 # edx-drf-extensions csrf app
 urlpatterns += [


### PR DESCRIPTION
**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
