### PR TITLE
feat: [OeX_Cred-224, OeX_Cred-363] add default storage and default issuance conf

### DIFF
--- a/credentials/apps/verifiable_credentials/settings.py
+++ b/credentials/apps/verifiable_credentials/settings.py
@@ -4,7 +4,10 @@ The settings contains a boolean, ENABLE_VERIFIABLE_CREDENTIALS, indicating
 whether this app is enabled. Settings probes the ENABLE_VERIFIABLE_CREDENTIALS.
 If true, it calls apply_settings(), passing in the Django settings
 """
+from django.urls import reverse
 
 
 def apply_settings(django_settings):
     django_settings.VC_DEFAULT_STANDARD = "OBv3"
+    django_settings.VC_DEFAULT_STORAGE = "verifiable_credentials.storages.LCWalletStorage"
+    django_settings.VC_DEFAULT_ISSUANCE_URL = django_settings.ROOT_URL + reverse("verifiable_credentials:api:v1:wallet")

--- a/credentials/apps/verifiable_credentials/storages.py
+++ b/credentials/apps/verifiable_credentials/storages.py
@@ -1,0 +1,6 @@
+class NoWalletStorage:
+    pass
+
+
+class LCWalletStorage:
+    pass

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -112,6 +112,8 @@ CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = "credentials.urls"
 
+ROOT_URL = "https://localhost:18150"
+
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = "credentials.wsgi.application"
 


### PR DESCRIPTION
…EFAULT_ISSUANCE_URL' to settings

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
