### PR TITLE
fix: make production plugins settings managed from environment

### DIFF
--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -29,6 +29,10 @@ EMAIL_BACKEND = "django_ses.SESBackend"
 AWS_SES_REGION_NAME = environ.get("AWS_SES_REGION_NAME", "us-east-1")
 AWS_SES_REGION_ENDPOINT = environ.get("AWS_SES_REGION_ENDPOINT", "email.us-east-1.amazonaws.com")
 
+# Inject plugin settings before the configuration file overrides (so it is possible to manage those settings via environment).
+add_plugins(__name__, PROJECT_TYPE, SettingsType.PRODUCTION)
+
+
 CONFIG_FILE = get_env_setting("CREDENTIALS_CFG")
 with open(CONFIG_FILE, encoding="utf-8") as f:
     config_from_yaml = yaml.safe_load(f)
@@ -60,5 +64,3 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.items():
     DATABASES["default"][override] = value
-
-add_plugins(__name__, PROJECT_TYPE, SettingsType.PRODUCTION)


### PR DESCRIPTION
At some point in time, plugin support was added to the Credentials project.
Plugins' settings are injected at the initialization step.
But the issue is **production settings are injected at the very end (when environment overrides are already applied)**, so it makes it impossible to manage any of the settings that are defined in plugins.

The PR addresses the issue by moving plugins' settings injection right before the environment configuration `yaml` processing.
