### PR TITLE
fix(deps): Credly Badges re-configuration

### DIFF
--- a/credentials/apps/badges/distribution/credly/pyproject.toml
+++ b/credentials/apps/badges/distribution/credly/pyproject.toml
@@ -32,9 +32,6 @@ badges = "credly_badges.apps:CredlyBadgesConfig"
 [project.urls]
 Repository = "https://github.com/openedx/credentials.git"
 
-[tool.setuptools]
-packages = ["credly_badges"]
-
 [tool.setuptools.dynamic]
 version = { attr = "credly_badges.__version__" }
 dependencies = { file = "requirements/base.txt" }

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e file:///edx/app/credentials/credentials/credentials/apps/badges/distribution/credly
-    # via -r requirements/dev.txt
 asgiref==3.7.2
     # via
     #   -r requirements/dev.txt
@@ -38,17 +36,17 @@ bcrypt==4.1.2
     # via
     #   -r requirements/dev.txt
     #   paramiko
-black==24.1.1
+black==24.2.0
     # via -r requirements/dev.txt
 bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.34.39
+boto3==1.34.40
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.34.39
+botocore==1.34.40
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -200,7 +198,7 @@ django-filter==23.5
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -450,6 +448,10 @@ openapi-codec==1.3.2
     #   -r requirements/production.txt
     #   django-rest-swagger
 openedx-atlas==0.6.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -52,9 +52,11 @@ segment-analytics-python
 social-auth-app-django
 xss-utils
 
-# Badges baked-in backends:
--e credentials/apps/badges/distribution/credly
-
 # TODO Install in configuration
 git+https://github.com/openedx/credentials-themes.git@0.3.22#egg=edx_credentials_themes==0.3.22
+
+# Badges baked-in backends:
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
+
+# FIXME: switch this to upstream once approved/merged:
 git+https://github.com/raccoongang/openedx-events.git@aci.main#egg=openedx_events

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e file:///edx/app/credentials/credentials/credentials/apps/badges/distribution/credly
-    # via -r requirements/base.in
 asgiref==3.7.2
     # via
     #   django
@@ -91,7 +89,7 @@ django-extensions==3.2.3
     # via -r requirements/base.in
 django-filter==23.5
     # via -r requirements/base.in
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via -r requirements/base.in
 django-ratelimit==4.1.0
     # via -r requirements/base.in
@@ -191,6 +189,8 @@ oauthlib==3.2.2
 openapi-codec==1.3.2
     # via django-rest-swagger
 openedx-atlas==0.6.0
+    # via -r requirements/base.in
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
     # via -r requirements/base.in
 openedx-events @ git+https://github.com/raccoongang/openedx-events.git@aci.main
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,36 +3,6 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
-# This is a temporary solution to override the real common_constraints.txt
-# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
-# See BOM-2721 for more details.
-# Below is the copied and edited version of common_constraints
-
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -8,6 +8,31 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e file:///edx/app/credentials/credentials/credentials/apps/badges/distribution/credly
-    # via -r requirements/test.txt
 asgiref==3.7.2
     # via
     #   -r requirements/test.txt
@@ -32,7 +30,7 @@ backports-zoneinfo==0.2.1
     #   django
 bcrypt==4.1.2
     # via paramiko
-black==24.1.1
+black==24.2.0
     # via -r requirements/test.txt
 bleach==6.1.0
     # via -r requirements/test.txt
@@ -160,7 +158,7 @@ django-extensions==3.2.3
     # via -r requirements/test.txt
 django-filter==23.5
     # via -r requirements/test.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via -r requirements/test.txt
 django-ratelimit==4.1.0
     # via -r requirements/test.txt
@@ -331,6 +329,8 @@ openapi-codec==1.3.2
     #   -r requirements/test.txt
     #   django-rest-swagger
 openedx-atlas==0.6.0
+    # via -r requirements/test.txt
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
     # via -r requirements/test.txt
 openedx-events @ git+https://github.com/raccoongang/openedx-events.git@aci.main
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.42.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.0.3
+setuptools==69.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e file:///edx/app/credentials/credentials/credentials/apps/badges/distribution/credly
-    # via -r requirements/base.txt
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
@@ -26,9 +24,9 @@ backports-zoneinfo==0.2.1
     #   django
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.34.39
+boto3==1.34.40
     # via django-ses
-botocore==1.34.39
+botocore==1.34.40
     # via
     #   boto3
     #   s3transfer
@@ -119,7 +117,7 @@ django-extensions==3.2.3
     # via -r requirements/base.txt
 django-filter==23.5
     # via -r requirements/base.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via -r requirements/base.txt
 django-ratelimit==4.1.0
     # via -r requirements/base.txt
@@ -257,6 +255,8 @@ openapi-codec==1.3.2
     #   -r requirements/base.txt
     #   django-rest-swagger
 openedx-atlas==0.6.0
+    # via -r requirements/base.txt
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
     # via -r requirements/base.txt
 openedx-events @ git+https://github.com/raccoongang/openedx-events.git@aci.main
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,8 +4,6 @@
 #
 #    make upgrade
 #
--e file:///edx/app/credentials/credentials/credentials/apps/badges/distribution/credly
-    # via -r requirements/base.txt
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
@@ -28,7 +26,7 @@ backports-zoneinfo==0.2.1
     # via
     #   -r requirements/base.txt
     #   django
-black==24.1.1
+black==24.2.0
     # via -r requirements/test.in
 bleach==6.1.0
     # via -r requirements/base.txt
@@ -138,7 +136,7 @@ django-extensions==3.2.3
     # via -r requirements/base.txt
 django-filter==23.5
     # via -r requirements/base.txt
-django-model-utils==4.3.1
+django-model-utils==4.4.0
     # via -r requirements/base.txt
 django-ratelimit==4.1.0
     # via -r requirements/base.txt
@@ -285,6 +283,8 @@ openapi-codec==1.3.2
     #   -r requirements/base.txt
     #   django-rest-swagger
 openedx-atlas==0.6.0
+    # via -r requirements/base.txt
+openedx-badges-credly @ git+https://github.com/raccoongang/credentials.git@aci.main#subdirectory=credentials/apps/badges/distribution/credly
     # via -r requirements/base.txt
 openedx-events @ git+https://github.com/raccoongang/openedx-events.git@aci.main
     # via


### PR DESCRIPTION
Update the way the baked-in Credly Badges app is installed.
It should fix the standard CI complaints.