### PR TITLE
fix: [HARROW_6-4438] add site filter to CourseRun lookup in copy_catalog

### DIFF
--- a/credentials/apps/catalog/utils.py
+++ b/credentials/apps/catalog/utils.py
@@ -239,7 +239,11 @@ class CatalogDataSynchronizer:
         program.course_runs.clear()
         for course_data in data["courses"]:
             for course_run_data in course_data["course_runs"]:
-                course_run = CourseRun.objects.get(course__uuid=course_data["uuid"], uuid=course_run_data["uuid"])
+                course_run = CourseRun.objects.get(
+                    course__site=self.site,
+                    course__uuid=course_data["uuid"],
+                    uuid=course_run_data["uuid"],
+                )
                 program.course_runs.add(course_run)
 
         return program


### PR DESCRIPTION
CatalogDataSynchronizer._parse_program looked up CourseRun by (course.uuid, run.uuid) only — no site filter — so when more than one Site has a populated catalog, the unfiltered .get() matches rows from multiple sites and raises MultipleObjectsReturned, aborting the entire copy_catalog run.

Add course__site=self.site to the lookup, mirroring the pattern already used for Organization.objects.get(site=self.site, ...) above and Program.objects.get(site=self.site, ...) in _parse_pathway. The model uniqueness contract (unique_together = ('site', 'uuid') / ('course', 'uuid')) already implied per-site isolation; this aligns behaviour with the schema.

Single-line behavioural change, no data migration. After deploy copy_catalog syncs each site independently.

Originally landed in the deprecated hippoteam/.../credentials!1 against HARROW_6-4371. Re-shipped here against the new raccoongang/credentials fork as part of the post-0.3.2 broken-certificates recovery tracked under HARROW_6-4438.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
